### PR TITLE
Add and Improve Grunt commands

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -64,6 +64,7 @@ module.exports = function(grunt) {
 
     concurrent: {
       local: ['watch', ['lab', 'shell:finish']],
+      plot: ['watch', ['shell:plot', 'shell:finish']],
       options: {
         logConcurrentOutput: true
       }
@@ -75,5 +76,5 @@ module.exports = function(grunt) {
   grunt.registerTask('default', ['lab_sync'])
 
   grunt.registerTask('remote', ['shell:remote'])
-  grunt.registerTask('plot', ['shell:plot'])
+  grunt.registerTask('plot', ['concurrent:plot'])
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -45,8 +45,7 @@ module.exports = function(grunt) {
           src: ['**'],
           dest: destination,
         }],
-        // pretend: true, // Don't do real IO; log only
-        // verbose: true // Display log messages when copying files
+        pretend: !grunt.option('prod'), // Don't do real IO; log only
       }
     },
 
@@ -76,7 +75,6 @@ module.exports = function(grunt) {
       finish: `echo "${finishMsg}"`,
       // TODO make smarter by autosearch
       plot: `${remoteCmd()} python3 main.py -e ${grunt.option('e')} -a`,
-      // TODO add a dev mode clear vs prod mode clear
       clear: 'rm -rf .cache __pycache__ */__pycache__ *egg-info htmlcov .coverage data/**/ data/*.log',
     },
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -59,7 +59,7 @@ module.exports = function(grunt) {
   }
 
   function remoteCmd() {
-    return (grunt.option('remote') || grunt.option('r')) ? 'xvfb-run -a -s "-screen 0 1400x900x24" --' : ''
+    return (grunt.option('remote')) ? 'xvfb-run -a -s "-screen 0 1400x900x24" --' : ''
   }
 
   function plotCmd() {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -55,7 +55,7 @@ module.exports = function(grunt) {
         files: `${source}/**`,
         tasks: ['sync'],
         options: {
-          debounceDelay: 5000,
+          debounceDelay: 60000,
         },
       }
     },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -57,7 +57,9 @@ module.exports = function(grunt) {
         }
       },
       remote: 'xvfb-run -a -s "-screen 0 1400x900x24" -- grunt',
-      finish: `echo "${finishMsg}"`
+      finish: `echo "${finishMsg}"`,
+      // TODO make smarter by autosearch
+      plot: `python3 main.py -e ${grunt.option('e')} -a`,
     },
 
     concurrent: {
@@ -73,4 +75,5 @@ module.exports = function(grunt) {
   grunt.registerTask('default', ['lab_sync'])
 
   grunt.registerTask('remote', ['shell:remote'])
+  grunt.registerTask('plot', ['shell:plot'])
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -57,17 +57,11 @@ module.exports = function(grunt) {
         }
       },
       remote: 'xvfb-run -a -s "-screen 0 1400x900x24" -- grunt',
-      killnoti: {
-        command: 'killall noti',
-        options: {
-          failOnError: false
-        }
-      },
       finish: `echo "${finishMsg}"`
     },
 
     concurrent: {
-      local: ['watch', ['lab', 'kill_noti', 'shell:finish']],
+      local: ['watch', ['lab', 'shell:finish']],
       options: {
         logConcurrentOutput: true
       }
@@ -79,5 +73,4 @@ module.exports = function(grunt) {
   grunt.registerTask('default', ['lab_sync'])
 
   grunt.registerTask('remote', ['shell:remote'])
-  grunt.registerTask('kill_noti', ['shell:killnoti'])
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,7 +21,7 @@ module.exports = function(grunt) {
     return (grunt.option('remote') || grunt.option('r')) ? 'xvfb-run -a -s "-screen 0 1400x900x24" --' : ''
   }
 
-  function notiCmd() {
+  function notiCmd(experiment) {
     return grunt.option('prod') ? `NOTI_SLACK_DEST='${config.NOTI_SLACK_DEST}' NOTI_SLACK_TOK='${config.NOTI_SLACK_TOK}' noti -k -t 'Experiment completed' -m '[${new Date().toISOString()}] ${experiment} on ${process.env.USER}'` : ''
   }
 
@@ -32,7 +32,7 @@ module.exports = function(grunt) {
   function composeCommand(experiment) {
     // override with custom command if has 'python'
     var cmd = _.includes(experiment, 'python') ? experiment : `python3 main.py -bgp -e ${experiment} -t 5`
-    return `${remoteCmd()} ${cmd} | tee -a ./data/terminal.log; ${notiCmd()}`
+    return `${remoteCmd()} ${cmd} | tee -a ./data/terminal.log; ${notiCmd(experiment)}`
   }
 
   require('load-grunt-tasks')(grunt)
@@ -77,7 +77,7 @@ module.exports = function(grunt) {
       // TODO make smarter by autosearch
       plot: `${remoteCmd()} python3 main.py -e ${grunt.option('e')} -a`,
       // TODO add a dev mode clear vs prod mode clear
-      clear: `rm -rf .cache __pycache__ */__pycache__ *egg-info htmlcov .coverage data/**/ data/*.log`,
+      clear: 'rm -rf .cache __pycache__ */__pycache__ *egg-info htmlcov .coverage data/**/ data/*.log',
     },
 
     concurrent: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -64,6 +64,8 @@ module.exports = function(grunt) {
       finish: `echo "${finishMsg}"`,
       // TODO make smarter by autosearch
       plot: `${remoteCmd()} python3 main.py -e ${grunt.option('e')} -a`,
+      // TODO add a dev mode clear vs prod mode clear
+      clear: `rm -rf .cache __pycache__ */__pycache__ *egg-info htmlcov .coverage data/**/ data/*.log`,
     },
 
     concurrent: {
@@ -80,4 +82,5 @@ module.exports = function(grunt) {
   grunt.registerTask('default', ['lab_sync'])
 
   grunt.registerTask('plot', ['concurrent:plot'])
+  grunt.registerTask('clear', ['shell:clear'])
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -3,8 +3,8 @@ const fs = require('fs')
 const resolve = require('resolve-dir')
 
 
-// generic experimentId matcher. index 2: experimentId, 3: experimentName
-const expIdRegex = /(\-e\s+)?(([a-zA-Z0-9_]+)_\d{4}\-\d{2}\-\d{2}_\d{6})/
+// generic experimentId matcher. index 2: experimentId, 3 or 4: experimentName
+const expIdRegex = /(\-e\s+)?(([a-zA-Z0-9_]+)_\d{4}\-\d{2}\-\d{2}_\d{6}|([a-zA-Z0-9_]+))/
 const historyPath = './config/history.json'
 const finishMsg = `
 ===========================================
@@ -22,20 +22,6 @@ module.exports = function(grunt) {
   const experimentTasks = _.map(experiments, function(name) {
     return `shell:exp:${name}`
   })
-
-  function remoteCmd() {
-    return (grunt.option('remote') || grunt.option('r')) ? 'xvfb-run -a -s "-screen 0 1400x900x24" --' : ''
-  }
-
-  function notiCmd(experiment) {
-    return grunt.option('prod') ? `NOTI_SLACK_DEST='${config.NOTI_SLACK_DEST}' NOTI_SLACK_TOK='${config.NOTI_SLACK_TOK}' noti -k -t 'Experiment completed' -m '[${new Date().toISOString()}] ${experiment} on ${process.env.USER}'` : ''
-  }
-
-  function composeCommand(experiment) {
-    // override with custom command if has 'python'
-    var cmd = _.includes(experiment, 'python') ? experiment : `python3 main.py -bgp -e ${experiment} -t 5`
-    return `${remoteCmd()} ${cmd} | tee -a ./data/terminal.log; ${notiCmd(experiment)}`
-  }
 
   function readHistory() {
     if (grunt.option('resume')) {
@@ -55,18 +41,37 @@ module.exports = function(grunt) {
   let history = readHistory()
 
   function writeHistory(history) {
-    fs.writeFile(historyPath, JSON.stringify(history, null, 4))
+    fs.writeFile(historyPath, JSON.stringify(history, null, 2))
   }
 
   function updateHistory(filepath) {
     const matchedPath = filepath.match(expIdRegex)
     if (matchedPath) {
       const experimentId = matchedPath[2]
-      const experimentName = matchedPath[3]
+      const experimentName = matchedPath[3] || matchedPath[4]
       history[experimentName] = experimentId
       writeHistory(history)
     }
   }
+
+  function remoteCmd() {
+    return (grunt.option('remote') || grunt.option('r')) ? 'xvfb-run -a -s "-screen 0 1400x900x24" --' : ''
+  }
+
+  function notiCmd(experiment) {
+    return grunt.option('prod') ? `NOTI_SLACK_DEST='${config.NOTI_SLACK_DEST}' NOTI_SLACK_TOK='${config.NOTI_SLACK_TOK}' noti -k -t 'Experiment completed' -m '[${new Date().toISOString()}] ${experiment} on ${process.env.USER}'` : ''
+  }
+
+  function composeCommand(experiment) {
+    if (grunt.option('resume')) {
+      // search and replace using history
+      // but if preinit hmm history is empty, so just dont replace
+    }
+    // override with custom command if has 'python'
+    var cmd = _.includes(experiment, 'python') ? experiment : `python3 main.py -bgp -e ${experiment} -t 5`
+    return `${remoteCmd()} ${cmd} | tee -a ./data/terminal.log; ${notiCmd(experiment)}`
+  }
+
 
 
   require('load-grunt-tasks')(grunt)

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -16,7 +16,7 @@ Experiments complete. Press Ctrl+C to exit.
 module.exports = function(grunt) {
   process.env.NODE_ENV = grunt.option('prod') ? 'production' : 'development'
   const config = require('config')
-  const source = './data'
+  const source = 'data'
   const destination = resolve(config.data_sync_destination)
   const experiments = config.experiments
   const experimentTasks = _.map(experiments, function(name) {
@@ -91,7 +91,8 @@ module.exports = function(grunt) {
     sync: {
       main: {
         files: [{
-          src: [`${source}/**`],
+          cwd: source,
+          src: [`**/*`],
           dest: destination,
         }],
         pretend: !grunt.option('prod'), // Don't do real IO
@@ -118,6 +119,9 @@ module.exports = function(grunt) {
       exp: {
         command(experiment) {
           return composeCommand(experiment)
+        },
+        options: {
+          stdout: true
         }
       },
       finish: `echo "${finishMsg}"`,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -25,10 +25,6 @@ module.exports = function(grunt) {
     return grunt.option('prod') ? `NOTI_SLACK_DEST='${config.NOTI_SLACK_DEST}' NOTI_SLACK_TOK='${config.NOTI_SLACK_TOK}' noti -k -t 'Experiment completed' -m '[${new Date().toISOString()}] ${experiment} on ${process.env.USER}'` : ''
   }
 
-  function watchCmd() {
-    return grunt.option('prod') ? 'watch' : 'shell:nowatch'
-  }
-
   function composeCommand(experiment) {
     // override with custom command if has 'python'
     var cmd = _.includes(experiment, 'python') ? experiment : `python3 main.py -bgp -e ${experiment} -t 5`
@@ -71,7 +67,6 @@ module.exports = function(grunt) {
           return composeCommand(experiment)
         }
       },
-      nowatch: 'echo "in development; watch mode not activated"',
       finish: `echo "${finishMsg}"`,
       // TODO make smarter by autosearch
       plot: `${remoteCmd()} python3 main.py -e ${grunt.option('e')} -a`,
@@ -79,8 +74,8 @@ module.exports = function(grunt) {
     },
 
     concurrent: {
-      default: [watchCmd(), ['lab', 'shell:finish']],
-      plot: [watchCmd(), ['shell:plot', 'shell:finish']],
+      default: ['watch', ['lab', 'shell:finish']],
+      plot: ['watch', ['shell:plot', 'shell:finish']],
       options: {
         logConcurrentOutput: true
       }

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ grunt
 grunt remote
 # for development of an experiment, quick run
 npm run dev
+# run analysis only, even when shits half-running
+grunt plot -e dev_dqn_2017-02-12_183415
 ```
 
 ### Running remotely

--- a/README.md
+++ b/README.md
@@ -99,16 +99,16 @@ To set up the lab experiments, edit `config/default.json`.
 python3 main.py -bgp -e dev_dqn -t 2 | tee -a ./data/terminal.log
 # run the lab in development mode (no watcher, no noti)
 grunt
-# run the lab in production mode
+# run analysis and plot only, even when lab is still running
+grunt plot
+# clean out dev data files and trash after dev
+grunt clear
+# add flag to run the lab in production mode
 grunt -prod
-# run the lab remotely
+# add flag to run the lab remotely (over ssh)
 grunt -remote
-# for development of an experiment, quick run
-npm run dev
-# run analysis only, even when shits half-running (in production, but don't need watcher)
-grunt plot -e=dev_dqn_2017-02-12_183415
-# if you're running it on a remote server
-grunt plot -e=dev_dqn_2017-02-12_183415 -remote
+# resume the past lab run, uses config/history.json
+grunt -resume
 ```
 
 ### Running remotely

--- a/README.md
+++ b/README.md
@@ -97,13 +97,15 @@ To set up the lab experiments, edit `config/default.json`.
 ```shell
 # pure python command (you still need to know this to customize Grunt)
 python3 main.py -bgp -e dev_dqn -t 2 | tee -a ./data/terminal.log
-# run the lab locally (no virtual display)
+# run the lab in development mode (no watcher, no noti)
 grunt
+# run the lab in production mode
+grunt -prod
 # run the lab remotely
 grunt -remote
 # for development of an experiment, quick run
 npm run dev
-# run analysis only, even when shits half-running
+# run analysis only, even when shits half-running (in production, but don't need watcher)
 grunt plot -e=dev_dqn_2017-02-12_183415
 # if you're running it on a remote server
 grunt plot -e=dev_dqn_2017-02-12_183415 -remote

--- a/README.md
+++ b/README.md
@@ -100,11 +100,13 @@ python3 main.py -bgp -e dev_dqn -t 2 | tee -a ./data/terminal.log
 # run the lab locally (no virtual display)
 grunt
 # run the lab remotely
-grunt remote
+grunt -remote
 # for development of an experiment, quick run
 npm run dev
 # run analysis only, even when shits half-running
 grunt plot -e=dev_dqn_2017-02-12_183415
+# if you're running it on a remote server
+grunt plot -e=dev_dqn_2017-02-12_183415 -remote
 ```
 
 ### Running remotely

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ grunt remote
 # for development of an experiment, quick run
 npm run dev
 # run analysis only, even when shits half-running
-grunt plot -e dev_dqn_2017-02-12_183415
+grunt plot -e=dev_dqn_2017-02-12_183415
 ```
 
 ### Running remotely

--- a/bin/copy-config
+++ b/bin/copy-config
@@ -4,8 +4,14 @@
 CONFIG_DIR=`pwd`/config
 EXAMPLE_CONFIG="$CONFIG_DIR/example-default.json"
 DEV_CONFIG="$CONFIG_DIR/default.json"
+PROD_CONFIG="$CONFIG_DIR/production.json"
 
 if [ ! -e "$DEV_CONFIG" ]; then
   cp $EXAMPLE_CONFIG $DEV_CONFIG
   echo "[ --- Created $DEV_CONFIG --- ]"
+fi
+
+if [ ! -e "$PROD_CONFIG" ]; then
+  cp $EXAMPLE_CONFIG $PROD_CONFIG
+  echo "[ --- Created $PROD_CONFIG --- ]"
 fi

--- a/bin/setup
+++ b/bin/setup
@@ -98,3 +98,7 @@ python3 -c "import theano; print('theano version:'); print(theano.__version__)"
 
 # install keras
 sudo python3 -m pip install keras
+
+# copy keys file if not already exist
+BIN_DIR=`pwd`/bin
+$BIN_DIR/copy-config

--- a/config/example-default.json
+++ b/config/example-default.json
@@ -4,18 +4,6 @@
   "NOTI_SLACK_TOK": "GET_SLACK_BOT_TOKEN_FROM_https://my.slack.com/services/new/bot",
   "experiments": [
         "dqn",
-        "double_dqn",
-        "dqn_freeze",
-        "sarsa -x 400",
-        "sarsa_exp -x 400",
-        "sarsa_offpol",
-        "mountain_dqn",
-        "mountain_sarsa -x 800",
-        "mountain_double_dqn",
-        "lunar_dqn",
-        "lunar_double_dqn",
-        "lunar_freeze",
-        "lunar_sarsa -x 1200",
-        "lunar_offpol_sarsa"
+        "lunar_dqn"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -8,11 +8,8 @@
   },
   "scripts": {
     "start": "grunt",
-    "remote": "xvfb-run -a -s \"-screen 0 1400x900x24\" -- grunt",
-    "dev": "python3 main.py -bgp -e dev_dqn -t 2 | tee -a ./data/terminal.log",
     "test": "python3 setup.py test",
-    "posttest": "rm -rf .cache __pycache__ */__pycache__ *egg-info htmlcov",
-    "clear": "rm -rf .cache __pycache__ */__pycache__ *egg-info htmlcov .coverage data/**/ data/*.log"
+    "posttest": "rm -rf .cache __pycache__ */__pycache__ *egg-info htmlcov"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openai_lab",
   "version": "1.0.0",
-  "description": "working out at the OpenAI gym",
+  "description": "An experimentation system for Reinforcement Learning using OpenAI and Keras",
   "main": "index.js",
   "directories": {
     "test": "test"
@@ -21,6 +21,7 @@
   "keywords": [
     "openai",
     "gym",
+    "lab",
     "reinforcement",
     "learning"
   ],

--- a/rl/analytics.py
+++ b/rl/analytics.py
@@ -236,8 +236,8 @@ def plot_experiment(data_df, trial_id):
                                     hue='solved_ratio_of_sessions')
             fig = df_plot.get_figure()
             fig.suptitle(wrap_text(experiment_id))
-            filename = './data/{}/experiment_plot_{}_vs_{}.png'.format(
-                experiment_id, x, y)
+            filename = './data/{}/{}_analysis_{}_vs_{}.png'.format(
+                experiment_id, experiment_id, x, y)
             fig.savefig(filename)
             fig.clear()
 
@@ -247,7 +247,7 @@ def plot_experiment(data_df, trial_id):
     fig.map(partial(sns.swarmplot, size=3))
     fig.fig.suptitle(wrap_text(experiment_id))
     fig.add_legend()
-    filename = './data/{}/experiment_plot_overview.png'.format(
+    filename = './data/{0}/{0}_analysis.png'.format(
         experiment_id)
     fig.savefig(filename)
 

--- a/rl/analytics.py
+++ b/rl/analytics.py
@@ -24,6 +24,7 @@ warnings.filterwarnings("ignore", module="matplotlib")
 
 
 STATS_COLS = [
+    'mean_rewards_per_epi_stats_mean_times_solved_ratio_of_sessions',
     'mean_rewards_per_epi_stats_mean',
     'mean_rewards_stats_mean',
     'epi_stats_mean',
@@ -33,7 +34,7 @@ STATS_COLS = [
     'trial_id'
 ]
 EXPERIMENT_GRID_Y_COLS = [
-    'mean_rewards_per_epi_stats_mean',
+    'mean_rewards_per_epi_stats_mean_times_solved_ratio_of_sessions',
     'mean_rewards_stats_mean',
     'max_total_rewards_stats_mean'
 ]
@@ -197,9 +198,19 @@ def compose_data(trial):
         'solved_t_stats': basic_stats(solved_t_array),
         'solved_time_taken_stats': basic_stats(solved_time_taken_array),
     }
+    stats.update({
+        'mean_rewards_per_epi_stats_mean_'
+        'times_solved_ratio_of_sessions': stats[
+            'mean_rewards_per_epi_stats']['mean'] * stats[
+            'solved_ratio_of_sessions']
+    })
 
     # summary metrics
     metrics = {
+        'mean_rewards_per_epi_stats_mean_'
+        'times_solved_ratio_of_sessions': stats[
+            'mean_rewards_per_epi_stats_mean_'
+            'times_solved_ratio_of_sessions'],
         'mean_rewards_per_epi_stats_mean': stats[
             'mean_rewards_per_epi_stats']['mean'],
         'mean_rewards_stats_mean': stats['mean_rewards_stats']['mean'],
@@ -287,7 +298,7 @@ def analyze_data(experiment_data_or_experiment_id):
             data_df[c] = data_df[c].astype('category')
 
     data_df.sort_values(
-        ['mean_rewards_per_epi_stats_mean'],
+        ['mean_rewards_per_epi_stats_mean_times_solved_ratio_of_sessions'],
         inplace=True, ascending=False)
 
     trial_id = experiment_data[0]['trial_id']

--- a/rl/util.py
+++ b/rl/util.py
@@ -343,7 +343,7 @@ def load_data_array_from_experiment_id(id_str):
 
 def save_experiment_data(data_df, trial_id):
     experiment_id = parse_experiment_id(trial_id)
-    filename = './data/{0}/experiment_data_{0}.csv'.format(experiment_id)
+    filename = './data/{0}/{0}_analysis_data.csv'.format(experiment_id)
     data_df.to_csv(filename, index=False)
     logger.info(
         'experiment data saved to {}'.format(filename))

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ def read(fname):
 # the setup
 setup(
     name='openai_lab',
-    version='0.0.1',
+    version='1.0.0',
     description='An experimentation system for Reinforcement Learning using OpenAI and Keras',
     long_description=read('README.md'),
     keywords='openai gym',


### PR DESCRIPTION
Add and Improve Grunt commands

- [x] kill `killnoti` since it's no longer needed
- [x] add Grunt task to plot, with watcher file sync
- [x] unify grunt commands to use `-remote` or `-r` to trigger remote mode
- [x] proper separation of `-prod` mode
- [x] add `config/history.json` (non git-comitted) file to resume and various grunt tasks
- [x] add smart resume, smart plotting using the history file
- [x] update analysis metrics to multiply by solved_ratio
- [x] rename analysis data and image files so it shows up at the top, and is identifiable by id
- [x] unify all commands to run from `grunt`, commands now are `grunt`, `grunt plot`, `grunt clear`; flags are `-prod`, `-remote`, `-resume`