### PR TITLE
Grunt fixes

### DIFF
--- a/rl/asset/experiment_specs.json
+++ b/rl/asset/experiment_specs.json
@@ -344,7 +344,7 @@
         "problem": "LunarLander-v2",
         "Agent": "DQN",
         "Memory": "LinearMemoryWithForgetting",
-        "Policy": "BolztmannPolicy",
+        "Policy": "EpsilonGreedyPolicy",
         "PreProcessor": "StackStates",
         "param": {
             "train_per_n_new_exp": 5,


### PR DESCRIPTION
- [x] change lunar_dqn to epsilon policy, correct previous typo crashing error