### PR TITLE
Solution: MountainCar-v0 with DoubleDQN

### DIFF
--- a/rl/spec/classic_experiment_specs.json
+++ b/rl/spec/classic_experiment_specs.json
@@ -728,9 +728,9 @@
     "PreProcessor": "NoPreProcessor",
     "param": {
       "batch_size": 32,
-      "lr": 0.001,
-      "gamma": 0.99,
-      "hidden_layers": [128, 64],
+      "lr": 0.01,
+      "gamma": 0.999,
+      "hidden_layers": [200],
       "hidden_layers_activation": "sigmoid",
       "output_layer_activation": "linear",
       "exploration_anneal_episodes": 400,

--- a/rl/spec/classic_experiment_specs.json
+++ b/rl/spec/classic_experiment_specs.json
@@ -627,7 +627,7 @@
     "HyperOptimizer": "RandomSearch",
     "Memory": "LinearMemoryWithForgetting",
     "Optimizer": "AdamOptimizer",
-    "Policy": "BoltzmannPolicy",
+    "Policy": "DoubleDQNBoltzmannPolicy",
     "PreProcessor": "NoPreProcessor",
     "param": {
       "max_evals": 30,
@@ -699,21 +699,22 @@
     "Policy": "BoltzmannPolicy",
     "PreProcessor": "NoPreProcessor",
     "param": {
-      "train_per_n_new_exp": 5,
+      "batch_size": 32,
       "lr": 0.001,
       "gamma": 0.99,
       "hidden_layers": [128, 64],
       "hidden_layers_activation": "sigmoid",
       "output_layer_activation": "linear",
       "exploration_anneal_episodes": 400,
-      "epi_change_lr": 600
+      "epi_change_lr": 800
     },
     "param_range": {
-      "lr": [0.001, 0.01],
+      "lr": [0.01, 0.02],
       "gamma": [0.99, 0.999],
       "hidden_layers": [
+        [200],
         [400],
-        [400, 200]
+        [800]
       ]
     }
   },
@@ -723,24 +724,25 @@
     "HyperOptimizer": "GridSearch",
     "Memory": "LinearMemoryWithForgetting",
     "Optimizer": "AdamOptimizer",
-    "Policy": "BoltzmannPolicy",
+    "Policy": "DoubleDQNBoltzmannPolicy",
     "PreProcessor": "NoPreProcessor",
     "param": {
-      "train_per_n_new_exp": 5,
+      "batch_size": 32,
       "lr": 0.001,
       "gamma": 0.99,
       "hidden_layers": [128, 64],
       "hidden_layers_activation": "sigmoid",
       "output_layer_activation": "linear",
       "exploration_anneal_episodes": 400,
-      "epi_change_lr": 600
+      "epi_change_lr": 800
     },
     "param_range": {
-      "lr": [0.001, 0.01],
+      "lr": [0.01, 0.02],
       "gamma": [0.99, 0.999],
       "hidden_layers": [
+        [200],
         [400],
-        [400, 200]
+        [800]
       ]
     }
   },
@@ -782,21 +784,22 @@
     "Policy": "BoltzmannPolicy",
     "PreProcessor": "NoPreProcessor",
     "param": {
-      "train_per_n_new_exp": 5,
+      "batch_size": 32,
       "lr": 0.001,
       "gamma": 0.99,
       "hidden_layers": [128, 64],
       "hidden_layers_activation": "sigmoid",
       "output_layer_activation": "linear",
       "exploration_anneal_episodes": 400,
-      "epi_change_lr": 600
+      "epi_change_lr": 800
     },
     "param_range": {
-      "lr": [0.001, 0.01],
+      "lr": [0.01, 0.02],
       "gamma": [0.99, 0.999],
       "hidden_layers": [
+        [200],
         [400],
-        [400, 200]
+        [800]
       ]
     }
   }

--- a/rl/spec/problems.json
+++ b/rl/spec/problems.json
@@ -32,7 +32,7 @@
   "MountainCar-v0": {
     "GYM_ENV_NAME": "MountainCar-v0",
     "SOLVED_MEAN_REWARD": -110.0,
-    "MAX_EPISODES": 1000,
+    "MAX_EPISODES": 1400,
     "REWARD_MEAN_LEN": 100
   },
   "MountainCarContinuous-v0": {


### PR DESCRIPTION
### Solution Submission

Once accepted, we will add the following to the OpenAI Lab [Best Solutions](http://kengz.me/openai_lab/#problems) and the code.

- name the Pull Request title like `Solution: CartPole-v0 with DQN`
- add PR label `solution`

Then, submit the following:

- [x] problem: MountainCar-v0
- [x] algorithm (commit code if new): DoubleDQN
- [x] best `fitness_score`: -0.03744196
- [x] author: kengz/lgraesser
- [x] commit `experiment_spec`: mountain_double_dqn
- _attach (not commit)_ the experiment files:
    - [x] `<experiment_id>_analysis_data.csv` (zip)
    - [x] `<best_trial_id>.json` (zip)
    - [x] `<best_trial_session_id>.png`
    - [x] `<experiment_id>_analysis.png`
    - [x] `<experiment_id>_analysis_correlation.png`

[mountain_double_dqn-2017_04_07_081835_analysis_data.csv.zip](https://github.com/kengz/openai_lab/files/907517/mountain_double_dqn-2017_04_07_081835_analysis_data.csv.zip)
[mountain_double_dqn-2017_04_07_081835_t6.json.zip](https://github.com/kengz/openai_lab/files/907514/mountain_double_dqn-2017_04_07_081835_t6.json.zip)
![mountain_double_dqn-2017_04_07_081835_t6_s1](https://cloud.githubusercontent.com/assets/8209263/24829897/d985010c-1c48-11e7-8ea6-2043be342e46.png)
![mountain_double_dqn-2017_04_07_081835_analysis](https://cloud.githubusercontent.com/assets/8209263/24829900/ddb31bec-1c48-11e7-8bb5-336ebba6a06e.png)
![mountain_double_dqn-2017_04_07_081835_analysis_correlation](https://cloud.githubusercontent.com/assets/8209263/24829901/dfce4776-1c48-11e7-99ed-ca7254cfe947.png)
