### PR TITLE
Fix DoubleDQN recompile_model missing model_2

### DIFF
--- a/rl/agent/double_dqn.py
+++ b/rl/agent/double_dqn.py
@@ -45,9 +45,9 @@ class DoubleDQN(DQN):
         '''rotate and recompile both models'''
         if self.epi_change_lr is not None:
             self.switch_models()  # to model_2
-            self.recompile_model(sys_vars)
+            super(DoubleDQN, self).recompile_model(sys_vars)
             self.switch_models()  # back to model
-            self.recompile_model(sys_vars)
+            super(DoubleDQN, self).recompile_model(sys_vars)
         return self.model
 
     def compute_Q_states(self, minibatch):

--- a/rl/agent/double_dqn.py
+++ b/rl/agent/double_dqn.py
@@ -31,6 +31,25 @@ class DoubleDQN(DQN):
             optimizer=self.optimizer.keras_optimizer_2)
         logger.info("Models 1 and 2 compiled")
 
+    def switch_models(self):
+         # Switch model 1 and model 2, also the optimizers
+        temp = self.model
+        self.model = self.model_2
+        self.model_2 = temp
+
+        temp_optimizer = self.optimizer.keras_optimizer
+        self.optimizer.keras_optimizer = self.optimizer.keras_optimizer_2
+        self.optimizer.keras_optimizer_2 = temp_optimizer
+
+    def recompile_model(self, sys_vars):
+        '''rotate and recompile both models'''
+        if self.epi_change_lr is not None:
+            self.switch_models()  # to model_2
+            self.recompile_model(sys_vars)
+            self.switch_models()  # back to model
+            self.recompile_model(sys_vars)
+        return self.model
+
     def compute_Q_states(self, minibatch):
         (Q_states, Q_next_states_select, _max) = super(
             DoubleDQN, self).compute_Q_states(minibatch)
@@ -44,16 +63,6 @@ class DoubleDQN(DQN):
         Q_next_states_max = Q_next_states[rows, Q_next_states_max_ind]
 
         return (Q_states, Q_next_states, Q_next_states_max)
-
-    def switch_models(self):
-         # Switch model 1 and model 2, also the optimizers
-        temp = self.model
-        self.model = self.model_2
-        self.model_2 = temp
-
-        temp_optimizer = self.optimizer.keras_optimizer
-        self.optimizer.keras_optimizer = self.optimizer.keras_optimizer_2
-        self.optimizer.keras_optimizer_2 = temp_optimizer
 
     def train_an_epoch(self):
         self.switch_models()

--- a/rl/spec/classic_experiment_specs.json
+++ b/rl/spec/classic_experiment_specs.json
@@ -705,16 +705,15 @@
       "hidden_layers": [128, 64],
       "hidden_layers_activation": "sigmoid",
       "output_layer_activation": "linear",
-      "exploration_anneal_episodes": 400,
-      "epi_change_lr": 800
+      "exploration_anneal_episodes": 100,
+      "epi_change_lr": 100
     },
     "param_range": {
       "lr": [0.01, 0.02],
       "gamma": [0.99, 0.999],
       "hidden_layers": [
         [200],
-        [400],
-        [800]
+        [400]
       ]
     }
   },
@@ -741,8 +740,7 @@
       "gamma": [0.99, 0.999],
       "hidden_layers": [
         [200],
-        [400],
-        [800]
+        [400]
       ]
     }
   },

--- a/rl/spec/classic_experiment_specs.json
+++ b/rl/spec/classic_experiment_specs.json
@@ -705,7 +705,7 @@
       "hidden_layers": [128, 64],
       "hidden_layers_activation": "sigmoid",
       "output_layer_activation": "linear",
-      "exploration_anneal_episodes": 100,
+      "exploration_anneal_episodes": 50,
       "epi_change_lr": 100
     },
     "param_range": {
@@ -732,7 +732,7 @@
       "hidden_layers": [200],
       "hidden_layers_activation": "sigmoid",
       "output_layer_activation": "linear",
-      "exploration_anneal_episodes": 100,
+      "exploration_anneal_episodes": 50,
       "epi_change_lr": 100
     },
     "param_range": {
@@ -788,16 +788,15 @@
       "hidden_layers": [128, 64],
       "hidden_layers_activation": "sigmoid",
       "output_layer_activation": "linear",
-      "exploration_anneal_episodes": 400,
-      "epi_change_lr": 800
+      "exploration_anneal_episodes": 50,
+      "epi_change_lr": 100
     },
     "param_range": {
       "lr": [0.01, 0.02],
       "gamma": [0.99, 0.999],
       "hidden_layers": [
         [200],
-        [400],
-        [800]
+        [400]
       ]
     }
   }

--- a/rl/spec/classic_experiment_specs.json
+++ b/rl/spec/classic_experiment_specs.json
@@ -733,8 +733,8 @@
       "hidden_layers": [200],
       "hidden_layers_activation": "sigmoid",
       "output_layer_activation": "linear",
-      "exploration_anneal_episodes": 400,
-      "epi_change_lr": 800
+      "exploration_anneal_episodes": 100,
+      "epi_change_lr": 100
     },
     "param_range": {
       "lr": [0.01, 0.02],


### PR DESCRIPTION
We observed that when `epi_change_lr` is present to trigger `recompile_model`, `DoubleDQN` calls upon its super method, and so only `self.model` (the first of two) is recompiled. This might be the cause for unstable mountain_dqn solutions.

*Note* also that the Lunar experiments using DoubleDQN have also been affected. On rerunning the fitness score might actually get higher.