### PR TITLE
Solution: LunarLanderContinuous-v2 with DDPG

### DIFF
--- a/rl/spec/box2d_experiment_specs.json
+++ b/rl/spec/box2d_experiment_specs.json
@@ -237,6 +237,37 @@
       ]
     }
   },
+  "lunar_cont_ddpg_linearnoise": {
+    "problem": "LunarLanderContinuous-v2",
+    "Agent": "DDPG",
+    "HyperOptimizer": "GridSearch",
+    "Memory": "LinearMemoryWithForgetting",
+    "Optimizer": "AdamOptimizer",
+    "Policy": "LinearNoisePolicy",
+    "PreProcessor": "NoPreProcessor",
+    "param": {
+      "batch_size": 64,
+      "n_epoch": 1,
+      "tau": 0.005,
+      "lr": 0.001,
+      "critic_lr": 0.001,
+      "exploration_anneal_episodes": 100,
+      "gamma": 0.99,
+      "hidden_layers": [600, 300],
+      "hidden_layers_activation": "relu",
+      "output_layer_activation": "tanh"
+    },
+    "param_range": {
+      "lr": [0.0001, 0.0005, 0.001],
+      "critic_lr": [0.001, 0.005, 0.01],
+      "gamma": [0.97, 0.99, 0.999],
+      "hidden_layers": [
+        [400, 300],
+        [600, 300],
+        [800, 400, 200]
+      ]
+    }
+  },
   "lunar_cont_ddpg_per_linearnoise": {
     "problem": "LunarLanderContinuous-v2",
     "Agent": "DDPG",


### PR DESCRIPTION
### Solution Submission

Once accepted, we will add the following to the OpenAI Lab [Best Solutions](http://kengz.me/openai_lab/#problems) and the code.

- name the Pull Request title like `Solution: CartPole-v0 with DQN`
- add PR label `solution`

Then, submit the following:

- [x] problem: LunarLanderContinuous-v2
- [x] algorithm (commit code if new): DDPG
- [x] best `fitness_score`: -0.03972519
- [x] author: kengz/lgraesser
- [x] commit `experiment_spec`: lunar_cont_ddpg_linearnoise
- _attach (not commit)_ the experiment files:
    - [x] `<experiment_id>_analysis_data.csv` (zip)
    - [x] `<best_trial_id>.json` (zip)
    - [x] `<best_trial_session_id>.png`
    - [x] `<experiment_id>_analysis.png`
    - [x] `<experiment_id>_analysis_correlation.png`

[lunar_cont_ddpg_linearnoise-2017_04_27_083255_analysis_data.csv.zip](https://github.com/kengz/openai_lab/files/981989/lunar_cont_ddpg_linearnoise-2017_04_27_083255_analysis_data.csv.zip)
[lunar_cont_ddpg_linearnoise-2017_04_27_083255_t14.json.zip](https://github.com/kengz/openai_lab/files/981988/lunar_cont_ddpg_linearnoise-2017_04_27_083255_t14.json.zip)
![lunar_cont_ddpg_linearnoise-2017_04_27_083255_t14_s0](https://cloud.githubusercontent.com/assets/8209263/25785627/86933b18-3353-11e7-9ba9-d8e940940c15.png)
![lunar_cont_ddpg_linearnoise-2017_04_27_083255_analysis](https://cloud.githubusercontent.com/assets/8209263/25785628/8b6028f4-3353-11e7-8806-f158e37cd3eb.png)
![lunar_cont_ddpg_linearnoise-2017_04_27_083255_analysis_correlation](https://cloud.githubusercontent.com/assets/8209263/25785629/8cd27d40-3353-11e7-83f2-e06e0e0f0490.png)
