### PR TITLE
Roadmap: Migration to PyTorch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ pytest-xdist>=1.15.0
 codacy-coverage>=1.3.3
 tensorflow>=1.0.0
 Keras>=1.2.2,<2.0.0
--e git+https://github.com/openai/gym.git#egg=gym[all]
+git+https://github.com/openai/gym.git#egg=gym[all]

--- a/rl/agent/conv_dqn.py
+++ b/rl/agent/conv_dqn.py
@@ -1,97 +1,135 @@
+from typing import List, Tuple
+import collections
 import math
-from rl.agent.dqn import DQN
+
+from torch import nn
+
+from rl import torch_utils
+from rl.agent import dqn
+
+ConvSpec = collections.namedtuple(
+        'ConvSpec', ['channels', 'kernel', 'stride'])
+
+def auto_architect_hidden_layers(conv_dqn):
+    conv_specs = []
+    stride = conv_dqn.stride
+    kernel = conv_dqn.kernel
+    output_channels = conv_dqn.num_initial_channels
+    cols, rows, input_channels = conv_dqn.env_spec['state_dim']
+
+    conv_specs.append(
+            ConvSpec(
+                channels=output_channels,
+                kernel=kernel,
+                stride=stride))
+    for i in range(1, conv_dqn.num_hidden_layers):
+        output_channels = output_channels * 2
+        cols = math.ceil(math.floor(cols - kernel - 1) / stride[0]) + 1
+        rows = math.ceil(math.floor(rows - kernel - 1) / stride[1]) + 1
+        if cols > 5 and rows > 5:
+            spec = ConvSpec(
+                    channels=output_channels,
+                    kernel=kernel,
+                    stride=stride)
+            conv_specs.append(spec)
+        else:
+            # stop addition of too many layers
+            # and from breakage by cols, rows growing to 0
+            break
+
+    return conv_specs
 
 
-class ConvDQN(DQN):
+def build_hidden_layers(conv_dqn) -> Tuple[List[nn.Conv2d], List[nn.Linear]]:
+    '''
+    build the hidden layers into model using parameter self.hidden_layers
+    Auto architecture infers the size of the hidden layers from the number
+    of channels in the first hidden layer and number of layers
+    With each successive layer the number of channels is doubled
+    Kernel size is fixed at 4, and stride at (2, 2)
+    No new layers are added if the cols or rows have dim <= 5
+    Enables hyperparameter optimization over network architecture
+    '''
+    if conv_dqn.auto_architecture:
+        print("Conv_dqn.num_initial_channels", conv_dqn.num_initial_channels)
+        print("Conv_dqn.num_hidden_layers", conv_dqn.num_hidden_layers)
+        conv_specs = auto_architect_hidden_layers(conv_dqn)
+    else:
+        conv_specs = []
+        for i in range(len(conv_dqn.hidden_layers)):
+            kernel = (conv_dqn.hidden_layers[i][1],
+                      conv_dqn.hidden_layers[i][2])
+            conv_specs.append(ConvSpec(
+                channels=conv_dqn.hidden_layers[i][0],
+                kernel=kernel,
+                stride=tuple(conv_dqn.hidden_layers[i][3])))
+
+    conv_layers = []
+    cols, rows, input_channels = conv_dqn.env_spec['state_dim']
+
+    for i in range(0, len(conv_specs)):
+        if i != 0:
+            input_channels = conv_specs[i - 1].channels
+        kernel = conv_specs[i].kernel
+        stride = conv_specs[i].stride
+        conv_layer = nn.Conv2d(
+                input_channels,
+                conv_specs[i].channels,
+                conv_specs[i].kernel,
+                stride=conv_specs[i].stride)
+        if isinstance(kernel, tuple):
+            row_kernel, col_kernel = kernel
+        elif isinstance(kernel, int):
+            col_kernel = kernel
+            row_kernel = kernel
+        else:
+            assert false
+        cols = math.ceil(math.floor(cols - col_kernel - 1) / stride[0]) + 1
+        rows = math.ceil(math.floor(rows - row_kernel - 1) / stride[1]) + 1
+        conv_layers.append(conv_layer)
+
+    fc_layers = [nn.Linear(rows * cols * conv_layers[-1].out_channels, 256)]
+
+    for layer in fc_layers + conv_layers:
+        dqn.lecun_init(layer.weight.data)
+        layer.bias.data.fill_(0.)
+
+    return (conv_layers, fc_layers)
+
+class ConvNet(nn.Module):
+
+    def __init__(self, conv_dqn):
+        super().__init__()
+        self._conv_layers, self._fc_hidden_layers = \
+                build_hidden_layers(conv_dqn)
+        self._output_layer = nn.Linear(
+                self._fc_hidden_layers[-1].weight.size()[1],
+                conv_dqn.env_spec['action_dim'])
+        self._hidden_layers_activation = dqn.get_activation_fn(
+                conv_dqn.hidden_layers_activation)
+        self._output_layer_activation = dqn.get_activation_fn(
+                conv_dqn.hidden_layers_activation)
+
+    def forward(self, x):
+        for conv_layer in self._conv_layers:
+            print("input size =", x.size())
+            print("conv layer =", conv_layer)
+            x = self._hidden_layers_activation(conv_layer(x))
+        x = x.view(-1, self._fc_hidden_layers.weight.size()[0])
+
+        for hidden_layer in self._fc_hidden_layers:
+            x = self._hidden_layers_activation(hidden_layer(x))
+        return self._output_layer_activation(self._output_layer(x))
+
+
+class ConvDQN(dqn.DQN):
 
     def __init__(self, *args, **kwargs):
-        from keras.layers.core import Dense, Flatten
-        from keras.layers.convolutional import Convolution2D
-        from keras import backend as K
-        if K.backend() == 'theano':
-            K.set_image_dim_ordering('tf')
-        self.Dense = Dense
-        self.Flatten = Flatten
-        self.Convolution2D = Convolution2D
-
         self.kernel = 4
         self.stride = (2, 2)
         super(ConvDQN, self).__init__(*args, **kwargs)
 
-    def build_hidden_layers(self, model):
-        '''
-        build the hidden layers into model using parameter self.hidden_layers
-        Auto architecture infers the size of the hidden layers from the number
-        of channels in the first hidden layer and number of layers
-        With each successive layer the number of channels is doubled
-        Kernel size is fixed at 4, and stride at (2, 2)
-        No new layers are added if the cols or rows have dim <= 5
-        Enables hyperparameter optimization over network architecture
-        '''
-        if self.auto_architecture:
-            num_channels = self.num_initial_channels
-            cols = self.env_spec['state_dim'][0]
-            rows = self.env_spec['state_dim'][1]
-            # input layer
-            model.add(
-                self.Convolution2D(
-                    num_channels,
-                    self.kernel,
-                    self.kernel,
-                    subsample=self.stride,
-                    input_shape=self.env_spec['state_dim'],
-                    activation=self.hidden_layers_activation,
-                    # border_mode='same',
-                    init='lecun_uniform'))
-
-            for i in range(1, self.num_hidden_layers):
-                num_channels *= 2
-                cols = math.ceil(
-                    math.floor(cols - self.kernel - 1) / self.stride[0]) + 1
-                rows = math.ceil(
-                    math.floor(rows - self.kernel - 1) / self.stride[1]) + 1
-                if cols > 5 and rows > 5:
-                    model.add(
-                        self.Convolution2D(
-                            num_channels,
-                            self.kernel,
-                            self.kernel,
-                            subsample=self.stride,
-                            activation=self.hidden_layers_activation,
-                            # border_mode='same',
-                            init='lecun_uniform'))
-                else:
-                    # stop addition of too many layers
-                    # and from breakage by cols, rows growing to 0
-                    break
-
-        else:
-            model.add(
-                self.Convolution2D(
-                    self.hidden_layers[0][0],
-                    self.hidden_layers[0][1],
-                    self.hidden_layers[0][2],
-                    subsample=self.hidden_layers[0][3],
-                    input_shape=self.env_spec['state_dim'],
-                    activation=self.hidden_layers_activation,
-                    # border_mode='same',
-                    init='lecun_uniform'))
-
-            if (len(self.hidden_layers) > 1):
-                for i in range(1, len(self.hidden_layers)):
-                    model.add(
-                        self.Convolution2D(
-                            self.hidden_layers[i][0],
-                            self.hidden_layers[i][1],
-                            self.hidden_layers[i][2],
-                            subsample=self.hidden_layers[i][3],
-                            activation=self.hidden_layers_activation,
-                            # border_mode='same',
-                            init='lecun_uniform'))
-
-        model.add(self.Flatten())
-        model.add(self.Dense(256,
-                             init='lecun_uniform',
-                             activation=self.hidden_layers_activation))
-
-        return model
+    def build_model(self):
+        self.model = ConvNet(self)
+        torch_utils.maybe_cuda(self.model)
+        return self.model

--- a/rl/agent/conv_dqn.py
+++ b/rl/agent/conv_dqn.py
@@ -1,8 +1,9 @@
-from typing import List, Tuple
+from typing import Any, List, Tuple
 
 import collections
 import math
 
+from torch import autograd
 from torch import nn
 
 from rl import torch_utils
@@ -10,6 +11,8 @@ from rl.agent import dqn
 
 ConvSpec = collections.namedtuple(
         'ConvSpec', ['channels', 'kernel', 'stride'])
+
+NumpyType = Any
 
 def auto_architect_hidden_layers(conv_dqn):
     conv_specs = []
@@ -120,6 +123,10 @@ class ConvNet(nn.Module):
             x = self._hidden_layers_activation(fc_layer(x))
         return self._output_layer_activation(self._output_layer(x))
 
+    def predict(self, data: NumpyType) -> NumpyType:
+        predicted = self.__call__(
+                autograd.Variable(torch_utils.from_numpy(data).float()))
+        return torch_utils.to_numpy(predicted.data)
 
 class ConvDQN(dqn.DQN):
 

--- a/rl/agent/double_dqn.py
+++ b/rl/agent/double_dqn.py
@@ -1,9 +1,14 @@
 import numpy as np
-from rl.agent.dqn import DQN
-from rl.util import logger, clone_model, clone_optimizer
+import torch
+
+from rl import torch_utils
+from rl.agent import dqn
+from rl.util import logger, clone_optimizer
 
 
-class DoubleDQN(DQN):
+# CR-soon fyquah: Is inheritance the best abstraction here? Sure, it saves a
+# few lines of code, but the code is quite hard to reason about.
+class DoubleDQN(dqn.DQN):
 
     '''
     The base class of double DQNs
@@ -11,35 +16,21 @@ class DoubleDQN(DQN):
 
     def build_model(self):
         super(DoubleDQN, self).build_model()
-
-        model_2 = clone_model(self.model)
-        logger.info("Model 2 summary")
-        model_2.summary()
-        self.model_2 = model_2
-
-        logger.info("Models 1 and 2 built")
+        self.model_2 = dqn.Net(self)
+        torch_util.maybe_cuda(self.model_2.cuda())
         return self.model, self.model_2
 
     def compile_model(self):
-        self.optimizer.keras_optimizer_2 = clone_optimizer(
-            self.optimizer.keras_optimizer)
-        self.model.compile(
-            loss='mse',
-            optimizer=self.optimizer.keras_optimizer)
-        self.model_2.compile(
-            loss='mse',
-            optimizer=self.optimizer.keras_optimizer_2)
+        super().compile_model()
+        self.torch_optimizer_2 = self.optimizer.torch_optimizer(
+                self.model_2.parameters())
         logger.info("Models 1 and 2 compiled")
 
     def switch_models(self):
-         # Switch model 1 and model 2, also the optimizers
-        temp = self.model
-        self.model = self.model_2
-        self.model_2 = temp
-
-        temp_optimizer = self.optimizer.keras_optimizer
-        self.optimizer.keras_optimizer = self.optimizer.keras_optimizer_2
-        self.optimizer.keras_optimizer_2 = temp_optimizer
+        # Switch model 1 and model 2, also the optimizers
+        self.model, self.model_2 = self.model_2, self.model
+        self.torch_optimizer, self.torch_optimizer_2 = \
+                self.torch_optimizer_2, self.torch_optimizer
 
     # def recompile_model(self, sys_vars):
     #     '''rotate and recompile both models'''
@@ -52,17 +43,24 @@ class DoubleDQN(DQN):
     #     return self.model
 
     def compute_Q_states(self, minibatch):
-        (Q_states, Q_next_states_select, _max) = super(
-            DoubleDQN, self).compute_Q_states(minibatch)
+        (Q_states, Q_next_states_select, _max) = \
+                super().compute_Q_states(minibatch)
         # Different from (single) dqn: Select max using model 2
-        Q_next_states_max_ind = np.argmax(Q_next_states_select, axis=1)
+        _, Q_next_states_max_ind = torch.max(Q_next_states_select, dim=1)
         # same as dqn again, but use Q_next_states_max_ind above
-        Q_next_states = np.clip(
-            self.model_2.predict(minibatch['next_states']),
-            -self.clip_val, self.clip_val)
-        rows = np.arange(Q_next_states_max_ind.shape[0])
+        Q_next_states = torch.clamp(
+                self.model_2(minibatch['next_states']),
+                min=-self.clip_val,
+                max=self.clip_val)
+        rows = torch.arange(
+                0, Q_next_states_max_ind.size()[0]).long()
+        rows = torch_utils.maybe_cuda(rows)
+        # CR-someday fyquah: Unnecessary conversion to-and-fro numpy is a
+        # temporary work-around over a bug in pytorch that disallows
+        # advanced indexing with GPU tensors in [Q_next_states].
+        Q_next_states_max_ind = torch_utils.from_numpy(
+                torch_utils.to_numpy(Q_next_states_max_ind.data))
         Q_next_states_max = Q_next_states[rows, Q_next_states_max_ind]
-
         return (Q_states, Q_next_states, Q_next_states_max)
 
     def train_an_epoch(self):

--- a/rl/agent/double_dqn.py
+++ b/rl/agent/double_dqn.py
@@ -17,7 +17,7 @@ class DoubleDQN(dqn.DQN):
     def build_model(self):
         super(DoubleDQN, self).build_model()
         self.model_2 = dqn.Net(self)
-        torch_util.maybe_cuda(self.model_2.cuda())
+        torch_utils.maybe_cuda(self.model_2.cuda())
         return self.model, self.model_2
 
     def compile_model(self):

--- a/rl/agent/dqn.py
+++ b/rl/agent/dqn.py
@@ -86,12 +86,11 @@ def build_hidden_layers(dqn) -> Tuple[List[nn.Linear], List[int]]:
             nn.Linear(dqn.env_spec['state_dim'], dqn.hidden_layers[0]))
 
         # inner hidden layer: no specification of input shape
-        if (len(dqn.hidden_layers) > 1):
-            for i in range(1, len(dqn.hidden_layers)):
-                layers.append(
-                        nn.Linear(
-                            dqn.hidden_layers[i - 1],
-                            dqn.hidden_layers[i]))
+        for i in range(1, len(dqn.hidden_layers)):
+            layers.append(
+                    nn.Linear(
+                        dqn.hidden_layers[i - 1],
+                        dqn.hidden_layers[i]))
 
     for layer in layers:
         tensor = layer.weight.data
@@ -118,7 +117,7 @@ class Net(nn.Module):
                 dqn.hidden_layers_activation)
         self._output_layer_activation = get_activation_fn(
                 dqn.output_layer_activation)
-        self._hidden_layers = hidden_layers
+        self._hidden_layers = nn.ModuleList(hidden_layers)
         self._output_layer = nn.Linear(
                 hidden_layer_dims[-1], dqn.env_spec['action_dim'])
 

--- a/rl/agent/dqn.py
+++ b/rl/agent/dqn.py
@@ -97,9 +97,8 @@ def build_hidden_layers(dqn) -> Tuple[List[nn.Linear], List[int]]:
         tensor = layer.weight.data
         fan_in = nn.init._calculate_correct_fan(tensor, 'fan_in')
         nn.init.uniform(
-                tensor, -math.sqrt(3 / fan_in), math.sqrt(3 / fan_in))
-        tensor.uniform_(-math.sqrt(3 / fan_in), math.sqrt(3 / fan_in))
-        layer.bias.data.fill_(0)
+                tensor, a=-math.sqrt(3 / fan_in), b=math.sqrt(3 / fan_in))
+        layer.bias.data.fill_(0.)
 
     return layers, dims
 

--- a/rl/agent/dqn.py
+++ b/rl/agent/dqn.py
@@ -175,7 +175,7 @@ class DQN(Agent):
         return self.model
 
     def compile_model(self):
-        self._loss_fn = torch.nn.MSELoss(size_average=False)
+        self._loss_fn = torch.nn.MSELoss(size_average=True)
         self.torch_optimizer = self.optimizer.torch_optimizer(
                 self.model.parameters())
         self.torch_optimizer.zero_grad()

--- a/rl/agent/dqn.py
+++ b/rl/agent/dqn.py
@@ -175,7 +175,7 @@ class DQN(Agent):
 
     def build_model(self):
         self.model = Net(self)
-        self.model.cuda()
+        torch_utils.maybe_cuda(self.model)
         return self.model
 
     def compile_model(self):
@@ -265,7 +265,6 @@ class DQN(Agent):
         return Q_targets
 
     def train_an_epoch(self):
-        print("HELLO")
         minibatch = parse_minibatch_to_torch_cuda(
             self.memory.rand_minibatch(self.batch_size))
         (Q_states, _states, Q_next_states_max) = \

--- a/rl/agent/dqn.py
+++ b/rl/agent/dqn.py
@@ -139,6 +139,11 @@ class Net(nn.Module):
             x = self._hidden_layers_activation(layer(x))
         return self._output_layer_activation(self._output_layer(x))
 
+    def predict(self, data: NumpyType) -> NumpyType:
+        print(data.shape)
+        predicted = self.__call__(
+                autograd.Variable(torch_utils.from_numpy(data).float()))
+        return torch_utils.to_numpy(predicted.data)
 
 class DQN(Agent):
 

--- a/rl/agent/dqn.py
+++ b/rl/agent/dqn.py
@@ -238,7 +238,7 @@ class DQN(Agent):
             t == (timestep_limit-1) or
             done)
 
-    def _compute_Q_states(self, minibatch):
+    def compute_Q_states(self, minibatch):
         # note the computed values below are batched in array
         Q_states = self.model(minibatch['states']).clamp(
                 min=-self.clip_val, max=self.clip_val)
@@ -261,7 +261,7 @@ class DQN(Agent):
         minibatch = parse_minibatch_to_torch(
             self.memory.rand_minibatch(self.batch_size))
         (Q_states, _states, Q_next_states_max) = \
-                self._compute_Q_states(minibatch)
+                self.compute_Q_states(minibatch)
         Q_targets = self.compute_Q_targets(
                 minibatch, Q_states, Q_next_states_max)
 

--- a/rl/agent/dqn.py
+++ b/rl/agent/dqn.py
@@ -140,7 +140,6 @@ class Net(nn.Module):
         return self._output_layer_activation(self._output_layer(x))
 
     def predict(self, data: NumpyType) -> NumpyType:
-        print(data.shape)
         predicted = self.__call__(
                 autograd.Variable(torch_utils.from_numpy(data).float()))
         return torch_utils.to_numpy(predicted.data)

--- a/rl/optimizer/adam.py
+++ b/rl/optimizer/adam.py
@@ -1,5 +1,17 @@
 from rl.optimizer.base_optimizer import Optimizer
 
+from torch import nn
+from torch.optim import adam
+
+def both(a, b):
+    if a is None or b is None:
+        return None
+    else:
+        return (a, b)
+
+def filter_non_none_values(d):
+    return { k : v for k, v in d.items() if v is not None }
+
 
 class AdamOptimizer(Optimizer):
 
@@ -15,11 +27,19 @@ class AdamOptimizer(Optimizer):
     '''
 
     def __init__(self, **kwargs):
-        from keras.optimizers import Adam
-        self.Adam = Adam
-
         self.optim_param_keys = ['lr', 'beta_1', 'beta_2', 'epsilon', 'decay']
         super(AdamOptimizer, self).__init__(**kwargs)
 
     def init_optimizer(self):
-        self.keras_optimizer = self.Adam(**self.optim_param)
+        from keras.optimizers import Adam
+        self.keras_optimizer = Adam(**self.optim_param)
+
+    def torch_optimizer(self, parameters: nn.ParameterList):
+        kwargs = filter_non_none_values({
+            "lr": self.optim_param.get("lr"),
+            "betas": both(self.optim_param.get("beta_1"), self.optim_param.get("beta_2")),
+            "eps": self.optim_param.get("epsilon"),
+            "weight_decay": self.optim_param.get("decay")
+        })
+        return adam.Adam(parameters, **kwargs)
+

--- a/rl/optimizer/base_optimizer.py
+++ b/rl/optimizer/base_optimizer.py
@@ -1,5 +1,7 @@
 from rl.util import log_self, logger
 
+from torch.optim import adam
+from torch import nn
 
 class Optimizer(object):
 
@@ -23,6 +25,9 @@ class Optimizer(object):
         self.optim_param.update(o_param)
 
     def init_optimizer(self):
+        raise NotImplementedError()
+
+    def torch_optimizer(self, parameters: nn.ParameterList):
         raise NotImplementedError()
 
     def change_optim_param(self, **new_param):

--- a/rl/policy/boltzmann.py
+++ b/rl/policy/boltzmann.py
@@ -27,7 +27,8 @@ class BoltzmannPolicy(Policy):
     def select_action(self, state):
         agent = self.agent
         state = np.expand_dims(state, axis=0)
-        torch_state = autograd.Variable(torch.from_numpy(state).float())
+        torch_state = autograd.Variable(
+                torch.from_numpy(state).float())
         Q_state = agent.model(torch_state).data.numpy()[0]  # extract from batch predict
         assert Q_state.ndim == 1
         Q_state = Q_state.astype('float64')  # fix precision overflow

--- a/rl/policy/boltzmann.py
+++ b/rl/policy/boltzmann.py
@@ -28,10 +28,8 @@ class BoltzmannPolicy(Policy):
     def select_action(self, state):
         agent = self.agent
         state = np.expand_dims(state, axis=0)
-        torch_state = autograd.Variable(
-                torch.from_numpy(state).float().cuda())
         # extract from batch predict
-        Q_state = torch_utils.to_numpy(agent.model(torch_state).data[0])
+        Q_state = agent.model.predict(state)[0]
         assert Q_state.ndim == 1
         Q_state = Q_state.astype('float64')  # fix precision overflow
         exp_values = np.exp(

--- a/rl/policy/boltzmann.py
+++ b/rl/policy/boltzmann.py
@@ -4,6 +4,7 @@ from torch import autograd
 
 from rl.policy.base_policy import Policy
 from rl.util import log_self
+from rl import torch_utils
 
 
 class BoltzmannPolicy(Policy):
@@ -28,8 +29,9 @@ class BoltzmannPolicy(Policy):
         agent = self.agent
         state = np.expand_dims(state, axis=0)
         torch_state = autograd.Variable(
-                torch.from_numpy(state).float())
-        Q_state = agent.model(torch_state).data.numpy()[0]  # extract from batch predict
+                torch.from_numpy(state).float().cuda())
+        # extract from batch predict
+        Q_state = torch_utils.to_numpy(agent.model(torch_state).data[0])
         assert Q_state.ndim == 1
         Q_state = Q_state.astype('float64')  # fix precision overflow
         exp_values = np.exp(

--- a/rl/policy/boltzmann.py
+++ b/rl/policy/boltzmann.py
@@ -1,4 +1,7 @@
 import numpy as np
+import torch
+from torch import autograd
+
 from rl.policy.base_policy import Policy
 from rl.util import log_self
 
@@ -24,7 +27,8 @@ class BoltzmannPolicy(Policy):
     def select_action(self, state):
         agent = self.agent
         state = np.expand_dims(state, axis=0)
-        Q_state = agent.model.predict(state)[0]  # extract from batch predict
+        torch_state = autograd.Variable(torch.from_numpy(state).float())
+        Q_state = agent.model(torch_state).data.numpy()[0]  # extract from batch predict
         assert Q_state.ndim == 1
         Q_state = Q_state.astype('float64')  # fix precision overflow
         exp_values = np.exp(

--- a/rl/spec/atari_experiment_specs.json
+++ b/rl/spec/atari_experiment_specs.json
@@ -19,11 +19,10 @@
       "hidden_layers_activation": "relu",
       "exploration_anneal_episodes": 3000,
       "epi_change_lr": 3000,
-      "auto_architecture": true,
+      "auto_architecture": false,
       "num_hidden_layers": 3,
       "num_initial_channels": 8,
       "max_mem_len": 500000
-
     },
     "param_range": {
       "lr": [0.001, 0.0001],

--- a/rl/spec/dev_experiment_specs.json
+++ b/rl/spec/dev_experiment_specs.json
@@ -93,34 +93,6 @@
       }
     }
   },
-  "dev_action_critic": {
-    "problem": "DevCartPole-v0",
-    "Agent": "DoubleDQN",
-    "HyperOptimizer": "GridSearch",
-    "Memory": "PrioritizedExperienceReplay",
-    "Optimizer": "AdamOptimizer",
-    "Policy": "BoltzmannPolicy",
-    "PreProcessor": "NoPreProcessor",
-    "param": {
-      "lr": 0.01,
-      "decay": 0.0,
-      "gamma": 0.99,
-      "n_epoch": 1,
-      "hidden_layers": [32],
-      "hidden_layers_activation": "sigmoid",
-      "exploration_anneal_episodes": 10,
-      "auto_architecture": false,
-      "num_hidden_layers": 3,
-      "first_hidden_layer_size": 512,
-      "e": 0.01,
-      "alpha": 0.6,
-      "max_mem_len": 7
-    },
-    "param_range": {
-      "gamma": [0.97, 0.99],
-      "lr": [0.01, 0.1]
-    }
-  },
   "dev_dqn": {
     "problem": "DevCartPole-v0",
     "Agent": "DQN",

--- a/rl/spec/dev_experiment_specs.json
+++ b/rl/spec/dev_experiment_specs.json
@@ -93,6 +93,34 @@
       }
     }
   },
+  "dev_action_critic": {
+    "problem": "DevCartPole-v0",
+    "Agent": "DoubleDQN",
+    "HyperOptimizer": "GridSearch",
+    "Memory": "PrioritizedExperienceReplay",
+    "Optimizer": "AdamOptimizer",
+    "Policy": "BoltzmannPolicy",
+    "PreProcessor": "NoPreProcessor",
+    "param": {
+      "lr": 0.01,
+      "decay": 0.0,
+      "gamma": 0.99,
+      "n_epoch": 1,
+      "hidden_layers": [32],
+      "hidden_layers_activation": "sigmoid",
+      "exploration_anneal_episodes": 10,
+      "auto_architecture": false,
+      "num_hidden_layers": 3,
+      "first_hidden_layer_size": 512,
+      "e": 0.01,
+      "alpha": 0.6,
+      "max_mem_len": 7
+    },
+    "param_range": {
+      "gamma": [0.97, 0.99],
+      "lr": [0.01, 0.1]
+    }
+  },
   "dev_dqn": {
     "problem": "DevCartPole-v0",
     "Agent": "DQN",

--- a/rl/torch_utils.py
+++ b/rl/torch_utils.py
@@ -5,3 +5,6 @@ def from_numpy(x):
 
 def to_numpy(tensor):
     return tensor.cpu().numpy()
+
+def maybe_cuda(tensor):
+    return tensor.cuda()

--- a/rl/torch_utils.py
+++ b/rl/torch_utils.py
@@ -1,10 +1,21 @@
 import torch
 
 def from_numpy(x):
-    return torch.from_numpy(x).cuda()
+    x = torch.from_numpy(x) 
+    if torch.cuda.device_count() > 0:
+        return x.cuda()
+    else:
+        return x
+
 
 def to_numpy(tensor):
-    return tensor.cpu().numpy()
+    if torch.cuda.device_count() > 0:
+        return tensor.cpu().numpy()
+    else:
+        return tensor.numpy()
 
 def maybe_cuda(tensor):
-    return tensor.cuda()
+    if torch.cuda.device_count() > 0:
+        return tensor.cuda()
+    else:
+        return tensor

--- a/rl/torch_utils.py
+++ b/rl/torch_utils.py
@@ -1,0 +1,7 @@
+import torch
+
+def from_numpy(x):
+    return torch.from_numpy(x).cuda()
+
+def to_numpy(tensor):
+    return tensor.cpu().numpy()

--- a/rl/torch_utils.py
+++ b/rl/torch_utils.py
@@ -1,21 +1,19 @@
 import torch
 
-def from_numpy(x):
-    x = torch.from_numpy(x) 
-    if torch.cuda.device_count() > 0:
-        return x.cuda()
-    else:
-        return x
-
-
-def to_numpy(tensor):
-    if torch.cuda.device_count() > 0:
-        return tensor.cpu().numpy()
-    else:
-        return tensor.numpy()
+USE_CUDA = torch.cuda.device_count() > 0
 
 def maybe_cuda(tensor):
-    if torch.cuda.device_count() > 0:
+    if USE_CUDA:
         return tensor.cuda()
     else:
         return tensor
+
+def from_numpy(x):
+    return maybe_cuda(torch.from_numpy(x))
+
+
+def to_numpy(tensor):
+    if USE_CUDA:
+        return tensor.cpu().numpy()
+    else:
+        return tensor.numpy()


### PR DESCRIPTION
This PR begins the roadmap task of PyTorch implementation.

Authors: @fyquah95 @kengz @lgraesser 

### Considerations

1. If we should switch entirely to PyTorch from Keras(tensorflow/theano)
    1.1 A complete migration is much cleaner in terms of dependency, complexity, code fragmentation. If so, release the new Lab at `v2.0.0`. Legacy usage shall be `v1.x.x`.
    1.2 Otherwise, it will be a bad mix of fragmented code in the lab. This will compromise experimental integrity as it will reintroduce the hidden side effects from incoherent implementations, and make it impossible to compare lab results reliably. See Lab's [Motivation](http://kengz.me/openai_lab/#motivations) for details.
    1.3 `PyTorch` is popular, that's a good thing. Also be aware that [OpenAI Baselines exist](https://github.com/openai/baselines), with 6 core RL algorithms implemented. They use `tensorflow`. We reached out multiple times to inquire about collaboration to no reply. We don't need to be compatible with them, but it can be good to refer.

2. How much time and energy will be spent on a full migration
    2.1 The aim is to not get stuck doing duplicate work (reimplementing existing algorithms), and to use PyTorch to move forward faster (implement new algorithms and research ideas).
    2.2 There are [7 existing agents](http://kengz.me/openai_lab/#agents-fitness-matrix), several reusable components (memory, optimizer, policy) that must be updated together so agent can be constructed in a combinatorial manner - to speed up research.
    2.3 Make adjustments in design accordingly for the idiosyncrasies of PyTorch.

### Checklist

An initial high level checklist. For now, all work could go into a branch piece by piece before the full PR into master, which must remain stable at `v1.x.x` for all users.

- [ ] implement existing components for agents in PyTorch: `memory, optimizer, policy`. No changes should be needed for `hyperoptimizer, preprocessor`
- [ ] proof the implementations by rerunning the ran experiments and matching/beating them in the [Fitness Matrix](http://kengz.me/openai_lab/#fitness-matrix). The [fitness score](http://kengz.me/openai_lab/#fitness-score) shall be able to measure most of the dimensions relevant for evaluation.
- [ ] show that PyTorch can be used for new work by implementing a new algorithm: pick any new ones from [OpenAI Baselines](https://github.com/openai/baselines), run experiments.
- [ ] package: fix installation breakages, pass CI/CC tests, update docs
- [ ] release `v2.0.0`